### PR TITLE
Fix bug with youtube.addPart('<part name>')

### DIFF
--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -151,11 +151,11 @@ var YouTube = function() {
    * @param maxResult
    * @param callback
    */
-  self.getTranding = function(regionCode, maxResult, callback) {
+  self.getTranding = function(regionCode, maxResult) {
     var validate = self.validate();
 
     if (validate !== null) {
-      callback(validate);
+      return validate;
     } else {
       self.addPart('snippet');
       self.addPart('contentDetails');
@@ -166,7 +166,7 @@ var YouTube = function() {
       self.addParam('regionCode', regionCode);
       self.addParam('maxResults', maxResult);
 
-      self.request(self.getUrl('videos'), callback);
+      return self.requestAsync(self.getUrl('videos'));
     }
   };
 

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -6,44 +6,44 @@ var YouTube = function() {
   var self = this;
 
   /**
-  * API v3 Url
-  * @type {string}
-  */
+   * API v3 Url
+   * @type {string}
+   */
   self.url = 'https://www.googleapis.com/youtube/v3/';
 
   /**
-  * params
-  * https://developers.google.com/youtube/v3/docs/search/list
-  * @type {Object}
-  */
+   * params
+   * https://developers.google.com/youtube/v3/docs/search/list
+   * @type {Object}
+   */
   self.params = {};
 
   self.parts = [];
 
   /**
-  * Set private key to class
-  * @param {string} key
-  */
+   * Set private key to class
+   * @param {string} key
+   */
   self.setKey = function(key) {
     self.addParam('key', key);
   };
 
   /**
-  *
-  * @param {string} name
-  */
+   *
+   * @param {string} name
+   */
   self.addPart = function(name) {
     self.parts.push(name);
   };
 
   /**
-  *
-  * Optional parameters
-  * https://developers.google.com/youtube/v3/docs/search/list
-  *
-  * @param {string} key
-  * @param {string} value
-  */
+   *
+   * Optional parameters
+   * https://developers.google.com/youtube/v3/docs/search/list
+   *
+   * @param {string} key
+   * @param {string} value
+   */
   self.addParam = function(key, value) {
     self.params[key] = value;
   };
@@ -57,18 +57,20 @@ var YouTube = function() {
   };
 
   /**
-  *
-  * @param {string} path
-  * @returns {string}
-  */
+   *
+   * @param {string} path
+   * @returns {string}
+   */
   self.getUrl = function(path) {
+    console.log(path);
+    console.log(self.params);
     return self.url + path + '?' + queryString.stringify(self.params);
   };
 
   /**
-  *
-  * @returns {string}
-  */
+   *
+   * @returns {string}
+   */
   self.getParts = function() {
     var joinedParts = self.parts.join(',');
     self.clearParts();
@@ -76,10 +78,10 @@ var YouTube = function() {
   };
 
   /**
-  * Simple http request
-  * @param {string} url
-  * @param {string} callback
-  */
+   * Simple http request
+   * @param {string} url
+   * @param {string} callback
+   */
   self.request = function(url, callback) {
     request(url, function(error, response, body) {
       if (error) {
@@ -98,9 +100,9 @@ var YouTube = function() {
   };
 
   /**
-  * Return error object
-  * @param {string} message
-  */
+   * Return error object
+   * @param {string} message
+   */
   self.newError = function(message) {
     return {
       error : {
@@ -110,8 +112,8 @@ var YouTube = function() {
   };
 
   /**
-  * Validate params
-  */
+   * Validate params
+   */
   self.validate = function() {
     if (!self.params.key) {
       return self.newError('Please set a key using setKey method. Get an key in https://console.developers.google.com');
@@ -122,8 +124,8 @@ var YouTube = function() {
   };
 
   /**
-  * Initialize parts
-  */
+   * Initialize parts
+   */
   self.clearParts = function() {
     self.parts = [];
   };
@@ -138,6 +140,9 @@ var YouTube = function() {
     self.deleteParam('part');
     self.deleteParam('regionCode');
     self.deleteParam('maxResults');
+    self.deleteParam('q');
+    self.deleteParam('eventType');
+    self.deleteParam('type');
 
     var validate = self.validate();
 
@@ -167,6 +172,9 @@ var YouTube = function() {
     self.parts = [];
     self.deleteParam('id');
     self.deleteParam('part');
+    self.deleteParam('eventType');
+    self.deleteParam('type');
+    self.deleteParam('q');
 
     var validate = self.validate();
 
@@ -187,11 +195,11 @@ var YouTube = function() {
   };
 
   /**
-  * Playlists data from Playlist Id
-  * @param {string} id
-  * @param {function} callback
-  * https://developers.google.com/youtube/v3/docs/playlists/list
-  */
+   * Playlists data from Playlist Id
+   * @param {string} id
+   * @param {function} callback
+   * https://developers.google.com/youtube/v3/docs/playlists/list
+   */
   self.getPlayListsById = function(id, callback) {
     var validate = self.validate();
 
@@ -214,11 +222,11 @@ var YouTube = function() {
   };
 
   /**
-  * Playlists data from Playlist Id
-  * @param {string} id
-  * @param {function} callback
-  * https://developers.google.com/youtube/v3/docs/playlistItems/list
-  */
+   * Playlists data from Playlist Id
+   * @param {string} id
+   * @param {function} callback
+   * https://developers.google.com/youtube/v3/docs/playlistItems/list
+   */
   self.getPlayListsItemsById = function(id, callback) {
     var validate = self.validate();
 
@@ -240,37 +248,44 @@ var YouTube = function() {
   };
 
   /**
-  * Videos data from query
-  * @param {string} query
-  * @param {int} maxResults
-  * @param {function} callback
-  */
-  self.search = function(query, maxResults, callback) {
+   * Videos data from query
+   * @param {string} query
+   * @param {int} maxResult
+   */
+  self.search = function(query, maxResult) {
     var validate = self.validate();
 
+    self.parts = [];
+    self.deleteParam('chart');
+    self.deleteParam('part');
+    self.deleteParam('id');
+    self.deleteParam('regionCode');
+    self.deleteParam('maxResults');
+
     if (validate !== null) {
-      callback(validate);
+      return validate;
     }
     else {
-      
 
       self.addPart('snippet');
-
       self.addParam('part', self.getParts());
       self.addParam('q', query);
-      self.addParam('maxResults', maxResults);
+      self.addParam('eventType', 'completed');
+      self.addParam('regionCode', 'US');
+      self.addParam('type', 'video');
+      self.addParam('maxResults', maxResult);
 
-      self.request(self.getUrl('search'), callback);
+      return self.requestAsync(self.getUrl('search'));
     }
   };
 
   /**
-  * Videos data from query
-  * @param {string} id
-  * @param {int} maxResults
-  * @param {function} callback
-  * Source: https://github.com/paulomcnally/youtube-node/pull/3/files
-  */
+   * Videos data from query
+   * @param {string} id
+   * @param {int} maxResults
+   * @param {function} callback
+   * Source: https://github.com/paulomcnally/youtube-node/pull/3/files
+   */
   self.related = function(id, maxResults, callback) {
     var validate = self.validate();
 

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -49,6 +49,14 @@ var YouTube = function() {
   };
 
   /**
+   * Delete params by key
+   * @param {string} key
+   */
+  self.deleteParam = function(key) {
+    delete self.params[key];
+  };
+
+  /**
   *
   * @param {string} path
   * @returns {string}
@@ -121,15 +129,20 @@ var YouTube = function() {
   };
 
   /**
-  * Video data from ID
-  * @param {string} id
-  * @param {function} callback
-  */
-  self.getById = function(id, callback) {
+   * Video data from ID
+   * @param {string} id
+   */
+  self.getById = function(id) {
+    self.parts = [];
+    self.deleteParam('chart');
+    self.deleteParam('part');
+    self.deleteParam('regionCode');
+    self.deleteParam('maxResults');
+
     var validate = self.validate();
 
     if (validate !== null) {
-      callback(validate);
+      return validate;
     }
     else {
 
@@ -141,7 +154,7 @@ var YouTube = function() {
       self.addParam('part', self.getParts());
       self.addParam('id', id);
 
-      self.request(self.getUrl('videos'), callback);
+      return self.requestAsync(self.getUrl('videos'));
     }
   };
 

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -146,6 +146,31 @@ var YouTube = function() {
   };
 
   /**
+   * Fetching trending videos based on a users region
+   * @param regionCode
+   * @param maxResult
+   * @param callback
+   */
+  self.getTranding = function(regionCode, maxResult, callback) {
+    var validate = self.validate();
+
+    if (validate !== null) {
+      callback(validate);
+    } else {
+      self.addPart('snippet');
+      self.addPart('contentDetails');
+      self.addPart('statistics');
+      self.addPart('status');
+      self.addParam('part', self.getParts());
+      self.addParam('chart', 'mostPopular');
+      self.addParam('regionCode', regionCode);
+      self.addParam('maxResults', maxResult);
+
+      self.request(self.getUrl('videos'), callback);
+    }
+  };
+
+  /**
   * Playlists data from Playlist Id
   * @param {string} id
   * @param {function} callback

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -62,8 +62,6 @@ var YouTube = function() {
    * @returns {string}
    */
   self.getUrl = function(path) {
-    console.log(path);
-    console.log(self.params);
     return self.url + path + '?' + queryString.stringify(self.params);
   };
 

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -62,7 +62,9 @@ var YouTube = function() {
   * @returns {string}
   */
   self.getParts = function() {
-    return self.parts.join(',');
+    var joinedParts = self.parts.join(',');
+    self.clearParts();
+    return joinedParts;
   };
 
   /**
@@ -130,7 +132,6 @@ var YouTube = function() {
       callback(validate);
     }
     else {
-      self.clearParts();
 
       self.addPart('snippet');
       self.addPart('contentDetails');
@@ -157,7 +158,6 @@ var YouTube = function() {
       callback(validate);
     }
     else {
-      self.clearParts();
 
       self.addPart('snippet');
       self.addPart('contentDetails');
@@ -185,7 +185,6 @@ var YouTube = function() {
       callback(validate);
     }
     else {
-      self.clearParts();
 
       self.addPart('contentDetails');
       self.addPart('id');
@@ -212,7 +211,7 @@ var YouTube = function() {
       callback(validate);
     }
     else {
-      self.clearParts();
+      
 
       self.addPart('snippet');
 
@@ -238,7 +237,6 @@ var YouTube = function() {
       callback(validate);
     }
     else {
-      self.clearParts();
 
       self.addPart('snippet');
 

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -164,6 +164,10 @@ var YouTube = function() {
    * @param maxResult
    */
   self.getTranding = function(regionCode, maxResult) {
+    self.parts = [];
+    self.deleteParam('id');
+    self.deleteParam('part');
+
     var validate = self.validate();
 
     if (validate !== null) {

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -149,7 +149,6 @@ var YouTube = function() {
    * Fetching trending videos based on a users region
    * @param regionCode
    * @param maxResult
-   * @param callback
    */
   self.getTranding = function(regionCode, maxResult) {
     var validate = self.validate();

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "url": "git://github.com/paulomcnally/youtube-node.git"
   },
   "devDependencies": {
+    "mocha": "^2.4.5",
     "should": "^4.3.0"
+  },
+  "scripts": {
+    "test": "mocha test"
   }
 }


### PR DESCRIPTION
Lets say I wanted to add liveStreamingDetails to video when calling getById method :

`var youtube = new Youtube(''KEY');`
`youtube.addPart('liveStreamingDetails');`
`youtube.getById('videoId', function(err, response){...});`

liveStreamingDetails woudn't be included in the api call because you would first clear the parts and then call .getUrl method. 

This way parts are cleared every time you serialize them to string.
