### PR TITLE
Adds maxResults to getPlayListsItemsById

### DIFF
--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -175,11 +175,18 @@ var YouTube = function() {
   /**
   * Playlists data from Playlist Id
   * @param {string} id
+  * @param {int} id
   * @param {function} callback
   * https://developers.google.com/youtube/v3/docs/playlistItems/list
   */
-  self.getPlayListsItemsById = function(id, callback) {
+  self.getPlayListsItemsById = function(id, maxResults, callback) {
+
     var validate = self.validate();
+    
+    if(typeof(maxResults) == "function"){
+      callback = maxResults;
+      maxResults = null;
+    }
 
     if (validate !== null) {
       callback(validate);
@@ -194,6 +201,8 @@ var YouTube = function() {
 
       self.addParam('part', self.getParts());
       self.addParam('playlistId', id);
+
+      maxResults && self.addParam('maxResults', maxResults);
 
       self.request(self.getUrl('playlistItems'), callback);
     }


### PR DESCRIPTION
As it says on the tin! Really handy to be able to add a maxResults to the requests, just as you can with the existing `search` method. Has handling for the `maxResults` parameter so that the change is backwards-compatible for existing users.