### PR TITLE
feat: replace request with phin 

### DIFF
--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -79,12 +79,12 @@ var YouTube = function () {
 	* @param {string} url
 	* @param {string} callback
 	*/
-	self.request = function (url, callback) {
+	self.request = async function (url, callback) {
 		try {
 			const response = await fetch(url);
 
 			var data = await response.json();
-			if (response.statusCode == 200) {
+			if (response.status == 200) {
 				return callback(null, data);
 			}
 			callback(data.error);

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -1,4 +1,4 @@
-var request = require('request');
+var phin = require('phin').unpromisified;
 var queryString = require('querystring');
 
 var YouTube = function() {
@@ -80,26 +80,16 @@ var YouTube = function() {
   * @param {string} callback
   */
   self.request = function(url, callback) {
-    request(url, function(error, response, body) {
+    phin({url, 'parse': 'json'}, function(error, response) {
       if (error) {
-        callback(error);
+        return callback(error);
       }
-      else {
-        
-        var data = {};
-        try {
-          data = JSON.parse(body);
-        } catch(e) {
-          data = {};
-        }
-        
-        if (response.statusCode == 200) {
-          callback(null, data);
-        }
-        else {
-          callback(data.error);
-        }
+
+      var data = response.body;
+      if (response.statusCode == 200) {
+        return callback(null, data);
       }
+      callback(data.error);
     });
   };
 

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -1,317 +1,317 @@
-var phin = require('phin').unpromisified;
+const fetch = require('node-fetch');
 var queryString = require('querystring');
 
-var YouTube = function() {
+var YouTube = function () {
 
-  var self = this;
+	var self = this;
 
-  /**
-  * API v3 Url
-  * @type {string}
-  */
-  self.url = 'https://www.googleapis.com/youtube/v3/';
+	/**
+	* API v3 Url
+	* @type {string}
+	*/
+	self.url = 'https://www.googleapis.com/youtube/v3/';
 
-  /**
-  * params
-  * https://developers.google.com/youtube/v3/docs/search/list
-  * @type {Object}
-  */
-  self.params = {};
+	/**
+	* params
+	* https://developers.google.com/youtube/v3/docs/search/list
+	* @type {Object}
+	*/
+	self.params = {};
 
-  self.parts = [];
+	self.parts = [];
 
-  /**
-  * Set private key to class
-  * @param {string} key
-  */
-  self.setKey = function(key) {
-    self.addParam('key', key);
-  };
+	/**
+	* Set private key to class
+	* @param {string} key
+	*/
+	self.setKey = function (key) {
+		self.addParam('key', key);
+	};
 
-  /**
-  *
-  * @param {string} name
-  */
-  self.addPart = function(name) {
-    self.parts.push(name);
-  };
+	/**
+	*
+	* @param {string} name
+	*/
+	self.addPart = function (name) {
+		self.parts.push(name);
+	};
 
-  /**
-  *
-  * Optional parameters
-  * https://developers.google.com/youtube/v3/docs/search/list
-  *
-  * @param {string} key
-  * @param {string} value
-  */
-  self.addParam = function(key, value) {
-    self.params[key] = value;
-  };
-  
-  /**
-  * Clear every parameter but the key
-  */
-  self.clearParams = function() {
-    self.params = {
-      key: self.params.key
-    }
-  };
+	/**
+	*
+	* Optional parameters
+	* https://developers.google.com/youtube/v3/docs/search/list
+	*
+	* @param {string} key
+	* @param {string} value
+	*/
+	self.addParam = function (key, value) {
+		self.params[key] = value;
+	};
 
-  /**
-  *
-  * @param {string} path
-  * @returns {string}
-  */
-  self.getUrl = function(path) {
-    return self.url + path + '?' + queryString.stringify(self.params);
-  };
+	/**
+	* Clear every parameter but the key
+	*/
+	self.clearParams = function () {
+		self.params = {
+			key: self.params.key
+		}
+	};
 
-  /**
-  *
-  * @returns {string}
-  */
-  self.getParts = function() {
-    return self.parts.join(',');
-  };
+	/**
+	*
+	* @param {string} path
+	* @returns {string}
+	*/
+	self.getUrl = function (path) {
+		return self.url + path + '?' + queryString.stringify(self.params);
+	};
 
-  /**
-  * Simple http request
-  * @param {string} url
-  * @param {string} callback
-  */
-  self.request = function(url, callback) {
-    phin({url, 'parse': 'json'}, function(error, response) {
-      if (error) {
-        return callback(error);
-      }
+	/**
+	*
+	* @returns {string}
+	*/
+	self.getParts = function () {
+		return self.parts.join(',');
+	};
 
-      var data = response.body;
-      if (response.statusCode == 200) {
-        return callback(null, data);
-      }
-      callback(data.error);
-    });
-  };
+	/**
+	* Simple http request
+	* @param {string} url
+	* @param {string} callback
+	*/
+	self.request = function (url, callback) {
+		try {
+			const response = await fetch(url);
 
-  /**
-  * Return error object
-  * @param {string} message
-  */
-  self.newError = function(message) {
-    return {
-      error : {
-        message: message
-      }
-    };
-  };
+			var data = await response.json();
+			if (response.statusCode == 200) {
+				return callback(null, data);
+			}
+			callback(data.error);
+		} catch (err) {
+			return callback(error);
+		}
+	};
 
-  /**
-  * Validate params
-  */
-  self.validate = function() {
-    if (!self.params.key) {
-      return self.newError('Please set a key using setKey method. Get an key in https://console.developers.google.com');
-    }
-    else {
-      return null;
-    }
-  };
+	/**
+	* Return error object
+	* @param {string} message
+	*/
+	self.newError = function (message) {
+		return {
+			error: {
+				message: message
+			}
+		};
+	};
 
-  /**
-  * Initialize parts
-  */
-  self.clearParts = function() {
-    self.parts = [];
-  };
+	/**
+	* Validate params
+	*/
+	self.validate = function () {
+		if (!self.params.key) {
+			return self.newError('Please set a key using setKey method. Get an key in https://console.developers.google.com');
+		}
+		else {
+			return null;
+		}
+	};
 
-  /**
-  * Video data from ID
-  * @param {string} id
-  * @param {function} callback
-  */
-  self.getById = function(id, callback) {
-    var validate = self.validate();
+	/**
+	* Initialize parts
+	*/
+	self.clearParts = function () {
+		self.parts = [];
+	};
 
-    if (validate !== null) {
-      callback(validate);
-    }
-    else {
-      self.addPart('snippet');
-      self.addPart('contentDetails');
-      self.addPart('statistics');
-      self.addPart('status');
+	/**
+	* Video data from ID
+	* @param {string} id
+	* @param {function} callback
+	*/
+	self.getById = function (id, callback) {
+		var validate = self.validate();
 
-      self.addParam('part', self.getParts());
-      self.addParam('id', id);
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.addPart('snippet');
+			self.addPart('contentDetails');
+			self.addPart('statistics');
+			self.addPart('status');
 
-      self.request(self.getUrl('videos'), callback);
-      
-      self.clearParams();
-      self.clearParts();      
-    }
-  };
-  
-  /**
-   * Get channel data based on ID
-   * @param {string} id
-   * @param {function} callback
-   */
-  self.getChannelById = function(id, callback) {
-    var validate = self.validate();
-    
-    if (validate !== null) {
-      callback(validate);
-    }
-    else {
-      self.clearParams();
-      self.clearParts();
-      
-      self.addPart('snippet');
-      self.addPart('contentDetails');
-      self.addPart('statistics');
-      self.addPart('status');
-      
-      self.addParam('part', self.getParts());
-      self.addParam('id', id);
-      
-      self.request(self.getUrl('channels'), callback);
-    }
-  };
-  
-  
-  /**
-  * Playlists data from Playlist Id
-  * @param {string} id
-  * @param {function} callback
-  * https://developers.google.com/youtube/v3/docs/playlists/list
-  */
-  self.getPlayListsById = function(id, callback) {
-    var validate = self.validate();
+			self.addParam('part', self.getParts());
+			self.addParam('id', id);
 
-    if (validate !== null) {
-      callback(validate);
-    }
-    else {
-      self.addPart('snippet');
-      self.addPart('contentDetails');
-      self.addPart('status');
-      self.addPart('player');
-      self.addPart('id');
+			self.request(self.getUrl('videos'), callback);
 
-      self.addParam('part', self.getParts());
-      self.addParam('id', id);
+			self.clearParams();
+			self.clearParts();
+		}
+	};
 
-      self.request(self.getUrl('playlists'), callback);
-      
-      self.clearParams();
-      self.clearParts();      
-    }
-  };
+	/**
+	 * Get channel data based on ID
+	 * @param {string} id
+	 * @param {function} callback
+	 */
+	self.getChannelById = function (id, callback) {
+		var validate = self.validate();
 
-  /**
-  * Playlists data from Playlist Id
-  * @param {string} id
-  * @param {int} maxResults
-  * @param {function} callback
-  * https://developers.google.com/youtube/v3/docs/playlistItems/list
-  */
-  self.getPlayListsItemsById = function(id, maxResults, callback) {
-    var validate = self.validate();
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.clearParams();
+			self.clearParts();
 
-    if(typeof(maxResults) == "function"){
-      callback = maxResults;
-      maxResults = null;
-    }
+			self.addPart('snippet');
+			self.addPart('contentDetails');
+			self.addPart('statistics');
+			self.addPart('status');
 
-    if (validate !== null) {
-      callback(validate);
-    }
-    else {
-      self.addPart('contentDetails');
-      self.addPart('id');
-      self.addPart('snippet');
-      self.addPart('status');
+			self.addParam('part', self.getParts());
+			self.addParam('id', id);
 
-      self.addParam('part', self.getParts());
-      self.addParam('playlistId', id);
+			self.request(self.getUrl('channels'), callback);
+		}
+	};
 
-      maxResults && self.addParam('maxResults', maxResults);
 
-      self.request(self.getUrl('playlistItems'), callback);
+	/**
+	* Playlists data from Playlist Id
+	* @param {string} id
+	* @param {function} callback
+	* https://developers.google.com/youtube/v3/docs/playlists/list
+	*/
+	self.getPlayListsById = function (id, callback) {
+		var validate = self.validate();
 
-      self.clearParams();
-      self.clearParts();      
-    }
-  };
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.addPart('snippet');
+			self.addPart('contentDetails');
+			self.addPart('status');
+			self.addPart('player');
+			self.addPart('id');
 
-  /**
-  * Videos data from query
-  * @param {string} query
-  * @param {int} maxResults
-  * @param {function} callback
-  */
-  self.search = function(query, maxResults, params, callback) {
+			self.addParam('part', self.getParts());
+			self.addParam('id', id);
 
-    if (typeof params !== 'object') {
-      if (typeof params === 'function') {
-        callback = params;
-      }
-      params = {};
-    }
+			self.request(self.getUrl('playlists'), callback);
 
-    var validate = self.validate();
+			self.clearParams();
+			self.clearParts();
+		}
+	};
 
-    if (validate !== null) {
-      callback(validate);
-    }
-    else {
-      self.addPart('snippet');
+	/**
+	* Playlists data from Playlist Id
+	* @param {string} id
+	* @param {int} maxResults
+	* @param {function} callback
+	* https://developers.google.com/youtube/v3/docs/playlistItems/list
+	*/
+	self.getPlayListsItemsById = function (id, maxResults, callback) {
+		var validate = self.validate();
 
-      self.addParam('part', self.getParts());
-      self.addParam('q', query);
-      self.addParam('maxResults', maxResults);
+		if (typeof (maxResults) == "function") {
+			callback = maxResults;
+			maxResults = null;
+		}
 
-      Object.keys(params).forEach(function(paramKey) {
-        if (params[paramKey] !== undefined) {
-          self.addParam(paramKey, params[paramKey]);
-        }
-      });
-      
-      self.request(self.getUrl('search'), callback);
-      
-      self.clearParams();
-      self.clearParts();      
-    }
-  };
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.addPart('contentDetails');
+			self.addPart('id');
+			self.addPart('snippet');
+			self.addPart('status');
 
-  /**
-  * Videos data from query
-  * @param {string} id
-  * @param {int} maxResults
-  * @param {function} callback
-  * Source: https://github.com/paulomcnally/youtube-node/pull/3/files
-  */
-  self.related = function(id, maxResults, callback) {
-    var validate = self.validate();
+			self.addParam('part', self.getParts());
+			self.addParam('playlistId', id);
 
-    if (validate !== null) {
-      callback(validate);
-    }
-    else {
-      self.addPart('snippet');
+			maxResults && self.addParam('maxResults', maxResults);
 
-      self.addParam('part', self.getParts());
-      self.addParam('relatedToVideoId', id);
-      self.addParam('maxResults', maxResults);
-      self.addParam('type', 'video');
-      self.addParam('order', 'relevance');
+			self.request(self.getUrl('playlistItems'), callback);
 
-      self.request(self.getUrl('search'), callback);
-      
-      self.clearParams();
-      self.clearParts();      
-    }
-  };
+			self.clearParams();
+			self.clearParts();
+		}
+	};
+
+	/**
+	* Videos data from query
+	* @param {string} query
+	* @param {int} maxResults
+	* @param {function} callback
+	*/
+	self.search = function (query, maxResults, params, callback) {
+
+		if (typeof params !== 'object') {
+			if (typeof params === 'function') {
+				callback = params;
+			}
+			params = {};
+		}
+
+		var validate = self.validate();
+
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.addPart('snippet');
+
+			self.addParam('part', self.getParts());
+			self.addParam('q', query);
+			self.addParam('maxResults', maxResults);
+
+			Object.keys(params).forEach(function (paramKey) {
+				if (params[paramKey] !== undefined) {
+					self.addParam(paramKey, params[paramKey]);
+				}
+			});
+
+			self.request(self.getUrl('search'), callback);
+
+			self.clearParams();
+			self.clearParts();
+		}
+	};
+
+	/**
+	* Videos data from query
+	* @param {string} id
+	* @param {int} maxResults
+	* @param {function} callback
+	* Source: https://github.com/paulomcnally/youtube-node/pull/3/files
+	*/
+	self.related = function (id, maxResults, callback) {
+		var validate = self.validate();
+
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.addPart('snippet');
+
+			self.addParam('part', self.getParts());
+			self.addParam('relatedToVideoId', id);
+			self.addParam('maxResults', maxResults);
+			self.addParam('type', 'video');
+			self.addParam('order', 'relevance');
+
+			self.request(self.getUrl('search'), callback);
+
+			self.clearParams();
+			self.clearParts();
+		}
+	};
 
     /**
      * Videos data from most popular list
@@ -319,25 +319,25 @@ var YouTube = function() {
      * @param {function} callback
      * Source: https://github.com/paulomcnally/youtube-node/pull/3/files
      */
-    self.getMostPopular = function(maxResults, callback) {
-        var validate = self.validate();
+	self.getMostPopular = function (maxResults, callback) {
+		var validate = self.validate();
 
-        if (validate !== null) {
-            callback(validate);
-        }
-        else {
-            self.addPart('snippet');
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.addPart('snippet');
 
-            self.addParam('part', self.getParts());
-            self.addParam('maxResults', maxResults);
-            self.addParam('chart', 'mostPopular');
+			self.addParam('part', self.getParts());
+			self.addParam('maxResults', maxResults);
+			self.addParam('chart', 'mostPopular');
 
-            self.request(self.getUrl('videos'), callback);
-          
-            self.clearParams();
-            self.clearParts();          
-        }
-    };
+			self.request(self.getUrl('videos'), callback);
+
+			self.clearParams();
+			self.clearParts();
+		}
+	};
 
     /**
      * Videos data from most popular list by videoCategoryId
@@ -345,26 +345,26 @@ var YouTube = function() {
      * @param {function} callback
      * Source: https://github.com/paulomcnally/youtube-node/pull/3/files
      */
-    self.getMostPopularByCategory = function(maxResults, videoCategoryId, callback) {
-        var validate = self.validate();
+	self.getMostPopularByCategory = function (maxResults, videoCategoryId, callback) {
+		var validate = self.validate();
 
-        if (validate !== null) {
-            callback(validate);
-        }
-        else {
-            self.addPart('snippet');
+		if (validate !== null) {
+			callback(validate);
+		}
+		else {
+			self.addPart('snippet');
 
-            self.addParam('part', self.getParts());
-            self.addParam('maxResults', maxResults);
-            self.addParam('chart', 'mostPopular');
-            self.addParam('videoCategoryId', videoCategoryId);
+			self.addParam('part', self.getParts());
+			self.addParam('maxResults', maxResults);
+			self.addParam('chart', 'mostPopular');
+			self.addParam('videoCategoryId', videoCategoryId);
 
-            self.request(self.getUrl('videos'), callback);
-          
-            self.clearParams();
-            self.clearParts();          
-        }
-    };
+			self.request(self.getUrl('videos'), callback);
+
+			self.clearParams();
+			self.clearParts();
+		}
+	};
 };
 
 module.exports = YouTube;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,456 @@
+{
+  "name": "youtube-node",
+  "version": "1.3.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+    },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "requires": {
+        "colors": "^1.1.2",
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.3.x",
+        "winston": "2.1.x"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "should": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/should/-/should-4.6.5.tgz",
+      "integrity": "sha1-DRI0bbvRsCj59Lt6nVRzZPw2qH8=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.3.1",
+        "should-format": "0.0.7",
+        "should-type": "0.0.4"
+      }
+    },
+    "should-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
+      "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.0.4"
+      }
+    },
+    "should-format": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.7.tgz",
+      "integrity": "sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.0.4"
+      }
+    },
+    "should-type": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
+      "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "requires": {
+        "async": "~0.9.0",
+        "deep-equal": "~0.2.1",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "1.0.x",
+        "rimraf": "2.x.x"
+      }
+    },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "colors": "^1.3.3",
-    "phin": "^3.4.0",
+    "node-fetch": "^2.6.0",
     "prompt": "^1.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "colors": "^1.3.3",
-    "prompt": "^1.0.0",
-    "request": "^2.88.0"
+    "phin": "^3.4.0",
+    "prompt": "^1.0.0"
   },
   "directories": {
     "lib": "./lib/youtube"


### PR DESCRIPTION
The request library has a lot of dependencies which can contain security issues. 

This pull request swaps the request dependency for phin which is the smallest http request library in the node ecosystem.

I have tested this with my project and it works as expected.
